### PR TITLE
Change Elasticsearch and Remove special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ GRANT REPLICATION CLIENT,PROCESS ON *.* TO 'zabbix'@'127.0.0.1'  IDENTIFIED BY '
 
 ### Dependencies
 
-zabbix-agent-extension-elasticsearch requires [zabbix-agent](http://www.zabbix.com/download) v3.4+ to run.
+zabbix-agent-extension-mysql requires [zabbix-agent](http://www.zabbix.com/download) v3.4+ to run.
 
 ### Zabbix configuration
 In order to start getting metrics, it is enough to import template and attach it to monitored node.

--- a/Template_App_MySQL.xml
+++ b/Template_App_MySQL.xml
@@ -7,7 +7,7 @@
             <name>Templates/Databases</name>
         </group>
         <group>
-            <name>￼￼Templates/Used</name>
+            <name>Templates/Used</name>
         </group>
     </groups>
     <templates>
@@ -20,7 +20,7 @@
                     <name>Templates/Databases</name>
                 </group>
                 <group>
-                    <name>￼￼Templates/Used</name>
+                    <name>Templates/Used</name>
                 </group>
             </groups>
             <applications>
@@ -2343,3 +2343,4 @@
         </value_map>
     </value_maps>
 </zabbix_export>
+


### PR DESCRIPTION
Hey There,

There was a simple typo in README file about elasticsearch (I think it's another template :smile:) and There are two special character (spacing) in XML file. 